### PR TITLE
:construction: 添加 QQ 频道私信支持

### DIFF
--- a/nonebot_plugin_all4one/middlewares/qqguild.py
+++ b/nonebot_plugin_all4one/middlewares/qqguild.py
@@ -58,6 +58,8 @@ class Middleware(BaseMiddleware):
             if isinstance(event, DirectMessageCreateEvent):
                 event_dict["detail_type"] = "private"
                 event_dict["user_id"] = event.get_user_id()
+                # 发送私信还需要临时频道 id
+                event_dict["guild_id"] = event.guild_id
             elif isinstance(event, MessageCreateEvent):
                 event_dict["detail_type"] = "channel"
                 event_dict["guild_id"] = event.guild_id
@@ -110,7 +112,7 @@ class Middleware(BaseMiddleware):
         message: OneBotMessage,
         **kwargs: Any,
     ) -> Dict[Union[Literal["message_id", "time"], str], Any]:
-        if detail_type != "channel":
+        if detail_type not in ["private", "channel"]:
             raise NotImplementedError
 
         message_list = []
@@ -130,12 +132,20 @@ class Middleware(BaseMiddleware):
                 file_image = f.read()
 
         try:
-            result = await self.bot.post_messages(
-                channel_id=int(channel_id),  # type: ignore
-                content=content,
-                msg_id=kwargs.get("event_id"),
-                file_image=file_image,  # type: ignore
-            )
+            if detail_type == "private":
+                result = await self.bot.post_dms_messages(
+                    guild_id=int(guild_id),  # type: ignore
+                    content=content,
+                    msg_id=kwargs.get("event_id"),
+                    file_image=file_image,  # type: ignore
+                )
+            else:
+                result = await self.bot.post_messages(
+                    channel_id=int(channel_id),  # type: ignore
+                    content=content,
+                    msg_id=kwargs.get("event_id"),
+                    file_image=file_image,  # type: ignore
+                )
         except Exception as e:
             raise e
         # FIXME: 如果是主动消息，返回的时间会是 None

--- a/nonebot_plugin_all4one/middlewares/qqguild.py
+++ b/nonebot_plugin_all4one/middlewares/qqguild.py
@@ -113,7 +113,7 @@ class Middleware(BaseMiddleware):
         **kwargs: Any,
     ) -> Dict[Union[Literal["message_id", "time"], str], Any]:
         if detail_type not in ["private", "channel"]:
-            raise NotImplementedError
+            raise ob_exception.UnsupportedParam("failed", 10004, "不支持的类型", None)
 
         message_list = []
         message = parse_obj_as(OneBotMessage, message)


### PR DESCRIPTION
需要 OneBot 应用在 send_message 时，同时附带临时频道 id。